### PR TITLE
Change access to member ImageEmbedder on Email object from internal t…

### DIFF
--- a/src/Postal/Email.cs
+++ b/src/Postal/Email.cs
@@ -55,7 +55,10 @@ namespace Postal
         /// </summary>
         public List<Attachment> Attachments { get; set; }
 
-        internal ImageEmbedder ImageEmbedder { get; private set; }
+        /// <summary>
+        /// ImageEmbedder that generates embed images from linked resources
+        /// </summary>
+        public ImageEmbedder ImageEmbedder { get; private set; }
 
         /// <summary>
         /// Adds an attachment to the email.


### PR DESCRIPTION
…o public

We need to extend the existing functionality of the EmailParser with
different handling of the Postal Header and integrate functionality to
move css styles inline. Therefore we need to write our own EmailParser
implementing IEmailParser Interface. Unfortunately with the internal on
the Email object we can't use the ImageEmbedder in our Parser. To ensure
extensibility of the EmailParser the ImageEmbedder should be accessable.